### PR TITLE
fix: suppress clippy warning for large enum variant in TopLevelCityObject

### DIFF
--- a/nusamai-plateau/src/models/mod.rs
+++ b/nusamai-plateau/src/models/mod.rs
@@ -38,6 +38,7 @@ use crate::BoundedBy;
 
 use self::uro::UNDERGROUND_BUILDING_SURFACE_MAPPINGS;
 
+#[allow(clippy::large_enum_variant)]
 #[citygml_property(name = "_:TopLevelFeatureProperty")]
 pub enum TopLevelCityObject {
     //


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new enum `TopLevelCityObject` to represent various city elements such as Buildings, Roads, and Water Bodies.
	- Added methods to retrieve names, IDs, descriptions, and surface mappings for city objects, enhancing data interaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->