### PR TITLE
chore: update dependencies for serde, serde_json, quick-xml, thiserror, and glob to latest versions

### DIFF
--- a/nusamai-citygml/Cargo.toml
+++ b/nusamai-citygml/Cargo.toml
@@ -16,9 +16,9 @@ log = "0.4.22"
 macros = { path = "./macros" }
 nusamai-projection = { path = "../nusamai-projection" }
 once_cell = "1.20.2"
-quick-xml = "0.37.1"
+quick-xml = "0.37.2"
 regex = "1.11.1"
-serde = { version = "1.0.216", features = ["derive"], optional = true }
-serde_json = { version = "1.0.133", features = ["indexmap"], optional = true }
-thiserror = "2.0.7"
+serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde_json = { version = "1.0.134", features = ["indexmap"], optional = true }
+thiserror = "2.0.9"
 url = { version = "2.5.3", features = ["serde"] }

--- a/nusamai-czml/Cargo.toml
+++ b/nusamai-czml/Cargo.toml
@@ -6,8 +6,8 @@ version = "0.1.0"
 [dependencies]
 chrono = { version = "0.4.39", features = ["serde"] }
 flatgeom = "0.0.2"
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = { version = "1.0.133", features = ["float_roundtrip"] }
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = { version = "1.0.134", features = ["float_roundtrip"] }
 
 [dev-dependencies]
-glob = "0.3.1"
+glob = "0.3.2"

--- a/nusamai-geojson/Cargo.toml
+++ b/nusamai-geojson/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 [dependencies]
 flatgeom = "0.0.2"
 geojson = "0.24.1"
-serde_json = { version = "1.0.133", features = ["indexmap"] }
+serde_json = { version = "1.0.134", features = ["indexmap"] }

--- a/nusamai-gltf/Cargo.toml
+++ b/nusamai-gltf/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 byteorder = "1.5.0"
 nusamai-gltf-json = { "path" = "nusamai-gltf-json" }
-serde_json = "1.0.133"
+serde_json = "1.0.134"
 
 [dev-dependencies]
-glob = "0.3.1"
+glob = "0.3.2"

--- a/nusamai-gltf/nusamai-gltf-json/Cargo.toml
+++ b/nusamai-gltf/nusamai-gltf-json/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = { version = "1.0.132", features = ["float_roundtrip"] }
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = { version = "1.0.134", features = ["float_roundtrip"] }
 serde_repr = "0.1.19"
 cesiumtiles = { git = "https://github.com/MIERUNE/cesiumtiles-rs.git" }
 
 [dev-dependencies]
-glob = "0.3.1"
+glob = "0.3.2"

--- a/nusamai-gpkg/Cargo.toml
+++ b/nusamai-gpkg/Cargo.toml
@@ -6,8 +6,8 @@ version = "0.1.0"
 [dependencies]
 flatgeom = "0.0.2"
 indexmap = "2.7.0"
-sqlx = { version = "0.8.2", features = ["runtime-tokio", "sqlite"] }
-thiserror = "2.0.7"
+sqlx = { version = "0.8.3", features = ["runtime-tokio", "sqlite"] }
+thiserror = "2.0.9"
 url = "2.5.4"
 
 [dev-dependencies]

--- a/nusamai-plateau/Cargo.toml
+++ b/nusamai-plateau/Cargo.toml
@@ -15,8 +15,8 @@ indexmap = "2.7.0"
 log = "0.4.22"
 nusamai-citygml = { path = "../nusamai-citygml", features = ["serde"] }
 once_cell = "1.20.2"
-quick-xml = "0.37.1"
-serde = { version = "1.0.216", features = ["derive", "rc"], optional = true }
+quick-xml = "0.37.2"
+serde = { version = "1.0.217", features = ["derive", "rc"], optional = true }
 stretto = "0.8.4"
 url = "2.5.4"
 
@@ -24,6 +24,6 @@ url = "2.5.4"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde", "std"] }
 clap = { version = "4.5.23", features = ["derive"] }
 lz4_flex = "0.11.3"
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.134"
 zstd = { version = "0.13.2", features = ["zdict_builder"] }

--- a/nusamai-projection/Cargo.toml
+++ b/nusamai-projection/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [dependencies]
 japan-geoid = "0.4.1"
-thiserror = "2.0.7"
+thiserror = "2.0.9"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `serde` and `serde_json` across multiple packages to latest minor versions
	- Updated `quick-xml`, `sqlx`, `thiserror`, `glob` dependencies to newer versions
	- Minor version increments for various Rust library dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->