### PR TITLE
fix: IntBuildingInstallation now has its own implementation

### DIFF
--- a/nusamai-citygml/src/parser.rs
+++ b/nusamai-citygml/src/parser.rs
@@ -111,7 +111,7 @@ impl Default for ParseContext<'_> {
     }
 }
 
-#[allow(elided_named_lifetimes)]
+#[allow(mismatched_lifetime_syntaxes)]
 impl<'a> CityGmlReader<'a> {
     pub fn new(context: ParseContext<'a>) -> Self {
         Self {
@@ -325,7 +325,7 @@ impl<'b, R: BufRead> SubTreeReader<'_, 'b, R> {
         }
     }
 
-    pub fn context(&self) -> &ParseContext {
+    pub fn context(&self) -> &ParseContext<'_> {
         &self.state.context
     }
 

--- a/nusamai-czml/src/models/articulation.rs
+++ b/nusamai-czml/src/models/articulation.rs
@@ -14,7 +14,7 @@ pub type Articulation = ArticulationValueType;
 #[serde(untagged)]
 pub enum ArticulationValueType {
     Array(Vec<ArticulationProperties>),
-    Object(ArticulationProperties),
+    Object(Box<ArticulationProperties>),
     Number(Number),
 }
 

--- a/nusamai-czml/src/models/checkerboard_material.rs
+++ b/nusamai-czml/src/models/checkerboard_material.rs
@@ -8,7 +8,7 @@ pub type CheckerboardMaterial = CheckerboardMaterialType;
 #[serde(untagged)]
 pub enum CheckerboardMaterialType {
     Array(Vec<CheckerboardMaterialProperties>),
-    Object(CheckerboardMaterialProperties),
+    Object(Box<CheckerboardMaterialProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -26,22 +26,22 @@ pub struct CheckerboardMaterialProperties {
 }
 
 fn default_even_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([255, 255, 255, 255])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_odd_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([0, 0, 0, 255])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_repeat() -> Repeat {
-    Repeat::Object(RepeatProperties {
+    Repeat::Object(Box::new(RepeatProperties {
         cartesian2: Some(vec![1.0, 1.0]),
         ..Default::default()
-    })
+    }))
 }

--- a/nusamai-czml/src/models/color.rs
+++ b/nusamai-czml/src/models/color.rs
@@ -9,12 +9,12 @@ pub type Color = ColorValueType;
 #[serde(untagged)]
 pub enum ColorValueType {
     Array(Vec<ColorProperties>),
-    Object(ColorProperties),
+    Object(Box<ColorProperties>),
 }
 
 impl Default for ColorValueType {
     fn default() -> Self {
-        ColorValueType::Object(ColorProperties::default())
+        ColorValueType::Object(Box::default())
     }
 }
 

--- a/nusamai-czml/src/models/czml_double.rs
+++ b/nusamai-czml/src/models/czml_double.rs
@@ -11,7 +11,7 @@ pub type CzmlDouble = DoubleValueType;
 #[serde(untagged)]
 pub enum DoubleValueType {
     Array(Vec<DoubleProperties>),
-    Object(DoubleProperties),
+    Object(Box<DoubleProperties>),
     Double(f32),
 }
 

--- a/nusamai-czml/src/models/czml_integer.rs
+++ b/nusamai-czml/src/models/czml_integer.rs
@@ -11,7 +11,7 @@ pub type CzmlInteger = IntegerValueType;
 #[serde(untagged)]
 pub enum IntegerValueType {
     Array(Vec<IntegerProperties>),
-    Object(IntegerProperties),
+    Object(Box<IntegerProperties>),
     Integer(i32),
 }
 

--- a/nusamai-czml/src/models/czml_polygon.rs
+++ b/nusamai-czml/src/models/czml_polygon.rs
@@ -188,15 +188,15 @@ fn is_default_fill(fill: &CzmlBoolean) -> bool {
 }
 
 fn default_material() -> Material {
-    Material::Object(MaterialProperties {
+    Material::Object(Box::new(MaterialProperties {
         solid_color: Some(SolidColorMaterial {
-            color: Color::Object(ColorProperties {
+            color: Color::Object(Box::new(ColorProperties {
                 rgba: Some(RgbaValue::Constant([255, 255, 255, 255])),
                 ..Default::default()
-            }),
+            })),
         }),
         ..Default::default()
-    })
+    }))
 }
 
 fn is_default_material(material: &Material) -> bool {
@@ -212,10 +212,10 @@ fn is_default_outline(outline: &CzmlBoolean) -> bool {
 }
 
 fn default_outline_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([0, 0, 0, 255])),
         ..Default::default()
-    })
+    }))
 }
 
 fn is_default_outline_color(outline_color: &Color) -> bool {

--- a/nusamai-czml/src/models/distance_display_condition.rs
+++ b/nusamai-czml/src/models/distance_display_condition.rs
@@ -9,7 +9,7 @@ pub type DistanceDisplayCondition = DistanceDisplayConditionValueType;
 #[serde(untagged)]
 pub enum DistanceDisplayConditionValueType {
     Array(Vec<DistanceDisplayConditionProperties>),
-    Object(DistanceDisplayConditionProperties),
+    Object(Box<DistanceDisplayConditionProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/nusamai-czml/src/models/grid_material.rs
+++ b/nusamai-czml/src/models/grid_material.rs
@@ -11,7 +11,7 @@ pub type GridMaterial = GridMaterialType;
 #[serde(untagged)]
 pub enum GridMaterialType {
     Array(Vec<GridMaterialProperties>),
-    Object(GridMaterialProperties),
+    Object(Box<GridMaterialProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -35,10 +35,10 @@ pub struct GridMaterialProperties {
 }
 
 fn default_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([0, 0, 0, 0])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_cell_alpha() -> CzmlDouble {
@@ -46,22 +46,22 @@ fn default_cell_alpha() -> CzmlDouble {
 }
 
 fn default_line_count() -> LineCount {
-    LineCount::Object(LineCountProperties {
+    LineCount::Object(Box::new(LineCountProperties {
         cartesian2: Some(vec![8.0, 8.0]),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_line_thickness() -> LineThickness {
-    LineThickness::Object(LineThicknessProperties {
+    LineThickness::Object(Box::new(LineThicknessProperties {
         cartesian2: Some(vec![1.0, 1.0]),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_line_offset() -> LineOffset {
-    LineOffset::Object(LineOffsetProperties {
+    LineOffset::Object(Box::new(LineOffsetProperties {
         cartesian2: Some(vec![1.0, 1.0]),
         ..Default::default()
-    })
+    }))
 }

--- a/nusamai-czml/src/models/line_count.rs
+++ b/nusamai-czml/src/models/line_count.rs
@@ -11,7 +11,7 @@ pub type LineCount = LineCountType;
 #[serde(untagged)]
 pub enum LineCountType {
     Array(Vec<LineCountProperties>),
-    Object(LineCountProperties),
+    Object(Box<LineCountProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/nusamai-czml/src/models/line_offset.rs
+++ b/nusamai-czml/src/models/line_offset.rs
@@ -11,7 +11,7 @@ pub type LineOffset = LineOffsetType;
 #[serde(untagged)]
 pub enum LineOffsetType {
     Array(Vec<LineOffsetProperties>),
-    Object(LineOffsetProperties),
+    Object(Box<LineOffsetProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/nusamai-czml/src/models/line_thickness.rs
+++ b/nusamai-czml/src/models/line_thickness.rs
@@ -11,7 +11,7 @@ pub type LineThickness = LineThicknessType;
 #[serde(untagged)]
 pub enum LineThicknessType {
     Array(Vec<LineThicknessProperties>),
-    Object(LineThicknessProperties),
+    Object(Box<LineThicknessProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/nusamai-czml/src/models/material.rs
+++ b/nusamai-czml/src/models/material.rs
@@ -10,7 +10,7 @@ pub type Material = MaterialType;
 #[serde(untagged)]
 pub enum MaterialType {
     Array(Vec<MaterialProperties>),
-    Object(MaterialProperties),
+    Object(Box<MaterialProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/nusamai-czml/src/models/model.rs
+++ b/nusamai-czml/src/models/model.rs
@@ -95,10 +95,10 @@ fn default_height_reference() -> HeightReference {
 }
 
 fn default_silhouette_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([255, 0, 0, 0])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_silhouette_size() -> CzmlDouble {
@@ -106,10 +106,10 @@ fn default_silhouette_size() -> CzmlDouble {
 }
 
 fn default_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([0, 0, 0, 0])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_color_blend_mode() -> ColorBlendMode {

--- a/nusamai-czml/src/models/node_transformations.rs
+++ b/nusamai-czml/src/models/node_transformations.rs
@@ -14,7 +14,7 @@ pub struct NodeTransformation {
 #[serde(untagged)]
 pub enum NodeTransformationValueType {
     Array(Vec<NodeTransformationProperties>),
-    Object(NodeTransformationProperties),
+    Object(Box<NodeTransformationProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/nusamai-czml/src/models/repeat.rs
+++ b/nusamai-czml/src/models/repeat.rs
@@ -11,12 +11,12 @@ pub type Repeat = RepeatType;
 #[serde(untagged)]
 pub enum RepeatType {
     Array(Vec<RepeatProperties>),
-    Object(RepeatProperties),
+    Object(Box<RepeatProperties>),
 }
 
 impl Default for RepeatType {
     fn default() -> Self {
-        RepeatType::Object(RepeatProperties::default())
+        RepeatType::Object(Box::default())
     }
 }
 

--- a/nusamai-czml/src/models/rotation.rs
+++ b/nusamai-czml/src/models/rotation.rs
@@ -13,7 +13,7 @@ pub struct Rotation {
 #[serde(untagged)]
 pub enum RotationValueType {
     Array(Vec<RotationProperties>),
-    Object(RotationProperties),
+    Object(Box<RotationProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -56,14 +56,14 @@ pub struct RotationProperties {
 impl Default for Rotation {
     fn default() -> Self {
         Self {
-            value: RotationValueType::Object(RotationProperties {
+            value: RotationValueType::Object(Box::new(RotationProperties {
                 unit_quaternion: Some(UnitQuaternionValue::Constant([0.0, 0.0, 0.0, 1.0])),
                 reference: None,
                 interpolatable_property: None,
                 deletable_property: None,
                 distance_display_condition_value_property: None,
                 reference_value_property: None,
-            }),
+            })),
         }
     }
 }

--- a/nusamai-czml/src/models/scale.rs
+++ b/nusamai-czml/src/models/scale.rs
@@ -15,7 +15,7 @@ pub struct Scale {
 #[serde(untagged)]
 pub enum ScaleValueType {
     Array(Vec<ScaleProperties>),
-    Object(ScaleProperties),
+    Object(Box<ScaleProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -36,14 +36,14 @@ pub struct ScaleProperties {
 impl Default for Scale {
     fn default() -> Self {
         Self {
-            value: ScaleValueType::Object(ScaleProperties {
+            value: ScaleValueType::Object(Box::new(ScaleProperties {
                 cartesian: Some(Cartesian3Value::Constant([1.0, 1.0, 1.0])),
                 reference: None,
                 interpolatable_property: None,
                 deletable_property: None,
                 distance_display_condition_value_property: None,
                 reference_value_property: None,
-            }),
+            })),
         }
     }
 }

--- a/nusamai-czml/src/models/solid_color_material.rs
+++ b/nusamai-czml/src/models/solid_color_material.rs
@@ -9,5 +9,5 @@ pub struct SolidColorMaterial {
 }
 
 fn default_color() -> Color {
-    Color::Object(Default::default())
+    Color::Object(Box::default())
 }

--- a/nusamai-czml/src/models/stripe_material.rs
+++ b/nusamai-czml/src/models/stripe_material.rs
@@ -11,7 +11,7 @@ pub type StripeMaterial = StripeMaterialType;
 #[serde(untagged)]
 pub enum StripeMaterialType {
     Array(Vec<StripeMaterialProperties>),
-    Object(StripeMaterialProperties),
+    Object(Box<StripeMaterialProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -42,17 +42,17 @@ fn default_orientation() -> StripeOrientation {
 }
 
 fn default_even_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([255, 255, 255, 0])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_odd_color() -> Color {
-    Color::Object(ColorProperties {
+    Color::Object(Box::new(ColorProperties {
         rgba: Some(RgbaValue::Constant([0, 0, 0, 0])),
         ..Default::default()
-    })
+    }))
 }
 
 fn default_offset() -> CzmlDouble {

--- a/nusamai-czml/src/models/translation.rs
+++ b/nusamai-czml/src/models/translation.rs
@@ -15,7 +15,7 @@ pub struct Translation {
 #[serde(untagged)]
 pub enum TranslationValueType {
     Array(Vec<TranslationProperties>),
-    Object(TranslationProperties),
+    Object(Box<TranslationProperties>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -36,14 +36,14 @@ pub struct TranslationProperties {
 impl Default for Translation {
     fn default() -> Self {
         Self {
-            value: TranslationValueType::Object(TranslationProperties {
+            value: TranslationValueType::Object(Box::new(TranslationProperties {
                 cartesian: Some(Cartesian3Value::Constant([0.0, 0.0, 0.0])),
                 reference: None,
                 interpolatable_property: None,
                 deletable_property: None,
                 distance_display_condition_value_property: None,
                 reference_value_property: None,
-            }),
+            })),
         }
     }
 }

--- a/nusamai-gpkg/src/handler.rs
+++ b/nusamai-gpkg/src/handler.rs
@@ -173,7 +173,7 @@ impl GpkgHandler {
         Ok(result)
     }
 
-    pub async fn begin(&mut self) -> Result<GpkgTransaction, GpkgError> {
+    pub async fn begin(&mut self) -> Result<GpkgTransaction<'_>, GpkgError> {
         Ok(GpkgTransaction::new(self.pool.begin().await?))
     }
 }

--- a/nusamai-plateau/src/models/building.rs
+++ b/nusamai-plateau/src/models/building.rs
@@ -47,7 +47,7 @@ pub struct Building {
     pub outer_building_installation: Vec<BuildingInstallation>,
 
     #[citygml(path = b"bldg:interiorBuildingInstallation/bldg:IntBuildingInstallation")]
-    pub interior_building_installation: Vec<BuildingInstallation>,
+    pub interior_building_installation: Vec<IntBuildingInstallation>,
 
     #[citygml(path = b"bldg:boundedBy")]
     pub bounded_by: Vec<BoundarySurfaceProperty>, // -> bldg:_BoundarySurface
@@ -146,7 +146,7 @@ pub struct BuildingPart {
     pub outer_building_installation: Vec<BuildingInstallation>,
 
     #[citygml(path = b"bldg:interiorBuildingInstallation/bldg:IntBuildingInstallation")]
-    pub interior_building_installation: Vec<BuildingInstallation>,
+    pub interior_building_installation: Vec<IntBuildingInstallation>,
 
     #[citygml(path = b"bldg:boundedBy")]
     pub bounded_by: Vec<BoundarySurfaceProperty>, // -> bldg:_BoundarySurface
@@ -372,7 +372,7 @@ pub struct Room {
     pub interior_furniture: Vec<BuildingFurniture>,
 
     #[citygml(path = b"bldg:roomInstallation/bldg:IntBuildingInstallation")]
-    pub room_installation: Vec<BuildingInstallation>,
+    pub room_installation: Vec<IntBuildingInstallation>,
 
     #[citygml(path = b"uro:ifcRoomAttribute")]
     pub ifc_room_attribute: Vec<uro::IfcAttributeProperty>, // -> uro:IfcAttribute
@@ -383,6 +383,24 @@ pub struct Room {
 
 #[citygml_feature(name = "bldg:BuildingInstallation")]
 pub struct BuildingInstallation {
+    #[citygml(path = b"bldg:class")]
+    pub class: Option<Code>,
+
+    #[citygml(path = b"bldg:function")]
+    pub function: Vec<Code>,
+
+    #[citygml(path = b"bldg:usage")]
+    pub usage: Vec<Code>,
+
+    #[citygml(path = b"bldg:boundedBy")]
+    pub bounded_by: Vec<BoundarySurfaceProperty>, // -> bldg:_BoundarySurface
+
+    #[citygml(path = b"uro:ifcBuildingInstallationAttribute")]
+    pub ifc_building_installation_attribute: Vec<uro::IfcAttributeProperty>, // -> uro:IfcAttribute
+}
+
+#[citygml_feature(name = "bldg:IntBuildingInstallation")]
+pub struct IntBuildingInstallation {
     #[citygml(path = b"bldg:class")]
     pub class: Option<Code>,
 

--- a/nusamai-plateau/src/models/iur/uro/underground_building.rs
+++ b/nusamai-plateau/src/models/iur/uro/underground_building.rs
@@ -42,7 +42,7 @@ pub struct UndergroundBuilding {
     pub outer_building_installation: Vec<bldg::BuildingInstallation>,
 
     #[citygml(path = b"bldg:interiorBuildingInstallation/bldg:IntBuildingInstallation")]
-    pub interior_building_installation: Vec<bldg::BuildingInstallation>,
+    pub interior_building_installation: Vec<bldg::IntBuildingInstallation>,
 
     #[citygml(path = b"bldg:boundedBy")]
     pub bounded_by: Vec<bldg::BoundarySurfaceProperty>, // -> bldg:_BoundarySurface

--- a/nusamai-plateau/tests/render_schema.rs
+++ b/nusamai-plateau/tests/render_schema.rs
@@ -22,7 +22,7 @@ fn render_schema() {
 
         assert_eq!(
             building.attributes["bldg:interiorBuildingInstallation"].type_ref,
-            schema::TypeRef::Named("bldg:BuildingInstallation".to_string())
+            schema::TypeRef::Named("bldg:IntBuildingInstallation".to_string())
         );
 
         // property stereo type


### PR DESCRIPTION
1. IntBuildingInstallation now has its own implementation, rather than borrowing an implementation from BuildingInstallation.
2. Lots of `clippy` fix.