### PR TITLE
fix: allow multiple LocalityName elements

### DIFF
--- a/nusamai-plateau/src/models/core.rs
+++ b/nusamai-plateau/src/models/core.rs
@@ -20,5 +20,5 @@ pub struct Country {
     #[citygml(path = b"xAL:CountryName")]
     name: Option<String>,
     #[citygml(path = b"xAL:Locality/xAL:LocalityName")]
-    locality_name: Option<String>,
+    locality_name: Vec<String>,
 }


### PR DESCRIPTION
Since in **extensible Address Language** (xAL), the LocalityName is unbounded.

```
				<xs:element name="LocalityName" minOccurs="0" maxOccurs="unbounded">
					<xs:annotation>
						<xs:documentation>Name of the locality</xs:documentation>
					</xs:annotation>
					<xs:complexType mixed="true">
						<xs:attribute name="Type"/>
						<xs:attributeGroup ref="grPostal"/>
						<xs:anyAttribute namespace="##other"/>
					</xs:complexType>
				</xs:element>
```

The current version triggers error when parsing valid PLATEAU citygml:

```
					<core:xalAddress>
						<xAL:AddressDetails>
							<xAL:Country>
								<xAL:CountryName>日本</xAL:CountryName>
								<xAL:Locality>
									<xAL:LocalityName Type="prefecture">福島県</xAL:LocalityName>
									<xAL:LocalityName Type="city">福島市</xAL:LocalityName>
								</xAL:Locality>
							</xAL:Country>
						</xAL:AddressDetails>
					</core:xalAddress>
```