### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: plateau-gis-converter
+  namespace: reearth
+  description: A GUI and CLI tool for converting PLATEAU's 3D city models (CityGML)
+    of Japan into various geospatial formats, including 3D Tiles, MVT, and GeoPackage.
+  annotations:
+    github.com/project-slug: reearth/plateau-gis-converter
+  links:
+  - url: https://github.com/reearth/plateau-gis-converter
+    title: GitHub
+    icon: github
+  - url: https://mierune.github.io/plateau-gis-converter/
+    title: Website
+    icon: web
+  tags:
+  - rust
+spec:
+  type: service
+  lifecycle: experimental
+  owner: reearth/flow


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `plateau-gis-converter` (namespace `reearth`)
- **Owner:** `reearth/flow`
- **Type / lifecycle:** `service` / `experimental`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.