### PR TITLE
fix: remove redundant into_iter() to satisfy clippy

### DIFF
--- a/nusamai-plateau/src/appearance.rs
+++ b/nusamai-plateau/src/appearance.rs
@@ -90,9 +90,7 @@ impl AppearanceStore {
                     let tex_idx = self.textures.len() as u32;
                     for tex_assoc in texture.target.drain(..) {
                         if let TextureAssociation::TexCoordList(tcl) = tex_assoc {
-                            for (ring, coords) in
-                                tcl.rings.into_iter().zip(tcl.coords_list.into_iter())
-                            {
+                            for (ring, coords) in tcl.rings.into_iter().zip(tcl.coords_list) {
                                 let coords = coords
                                     .chunks_exact(2)
                                     .map(|v| [v[0], v[1]])


### PR DESCRIPTION
## Summary

`cargo clippy --all -- -D warnings` fails on the latest stable Rust (1.96) with `clippy::useless_conversion` in `nusamai-plateau/src/appearance.rs`:

```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
  --> nusamai-plateau/src/appearance.rs:94:59
```

`Iterator::zip` accepts any `IntoIterator`, so the explicit `.into_iter()` on `coords_list` is unnecessary. This removes it.

## Verification

Ran the same command CI uses locally — passes clean:

```
cargo clippy --all -- -D warnings
    Finished `dev` profile ... target(s)
```